### PR TITLE
Fix README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Compiled for armv7
 
 # Dependencies
 
-for debian based distros:
+For Debian-based distros:
 
-`sudo apt-get install flex bison gperf ruby perl libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-devlibpng-dev libjpeg-dev python libX11-dev libxext-dev`
+`sudo apt-get install flex bison gperf ruby perl libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-dev libpng-dev libjpeg-dev python libX11-dev libxext-dev`


### PR DESCRIPTION
Minor typo for the apt-get copypasteable.